### PR TITLE
feat: add basic logs storage implementation

### DIFF
--- a/database/logs.go
+++ b/database/logs.go
@@ -1,0 +1,139 @@
+package database
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// InsertLogsData inserts logs telemetry data into the database
+func InsertLogsData(data map[string]interface{}) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	resourceLogs, ok := data["resourceLogs"].([]interface{})
+	if !ok {
+		return fmt.Errorf("invalid logs data: missing resourceLogs")
+	}
+
+	for _, rl := range resourceLogs {
+		resourceLog, ok := rl.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Get or create resource
+		var resourceID int64
+		if resource, ok := resourceLog["resource"].(map[string]interface{}); ok {
+			resourceID, err = GetOrCreateResource(tx, resource)
+			if err != nil {
+				return fmt.Errorf("failed to process resource: %w", err)
+			}
+		}
+
+		// Process scope logs
+		scopeLogs, ok := resourceLog["scopeLogs"].([]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, sl := range scopeLogs {
+			scopeLog, ok := sl.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			// Get or create scope
+			var scopeID int64
+			if scope, ok := scopeLog["scope"].(map[string]interface{}); ok {
+				scopeID, err = GetOrCreateScope(tx, scope)
+				if err != nil {
+					return fmt.Errorf("failed to process scope: %w", err)
+				}
+			}
+
+			// Process log records
+			logRecords, ok := scopeLog["logRecords"].([]interface{})
+			if !ok {
+				continue
+			}
+
+			for _, lr := range logRecords {
+				logRecord, ok := lr.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				if err := InsertLogRecord(tx, logRecord, resourceID, scopeID); err != nil {
+					return fmt.Errorf("failed to insert log record: %w", err)
+				}
+			}
+		}
+	}
+
+	return tx.Commit()
+}
+
+// InsertLogRecord inserts a single log record into the database
+func InsertLogRecord(tx *sql.Tx, logRecord map[string]interface{}, resourceID, scopeID int64) error {
+	// Parse timestamps
+	timeUnix := int64(0)
+	if t, ok := logRecord["timeUnixNano"].(string); ok && t != "" {
+		timeUnix = parseTimeNano(t)
+	}
+
+	observedTime := int64(0)
+	if ot, ok := logRecord["observedTimeUnixNano"].(string); ok && ot != "" {
+		observedTime = parseTimeNano(ot)
+	}
+
+	// Extract severity
+	severityNumber := int64(0)
+	if sn, ok := logRecord["severityNumber"].(float64); ok {
+		severityNumber = int64(sn)
+	}
+	severityText, _ := logRecord["severityText"].(string)
+
+	// Extract body
+	var bodyJSON []byte
+	var err error
+	if body, ok := logRecord["body"]; ok {
+		bodyJSON, err = json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal log body: %w", err)
+		}
+	}
+
+	// Extract attributes
+	attributes, _ := logRecord["attributes"]
+	attributesJSON, err := json.Marshal(attributes)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log attributes: %w", err)
+	}
+
+	// Extract trace context
+	traceID, _ := logRecord["traceId"].(string)
+	spanID, _ := logRecord["spanId"].(string)
+
+	// Extract flags
+	flags := int64(0)
+	if f, ok := logRecord["flags"].(float64); ok {
+		flags = int64(f)
+	}
+
+	// Insert log record
+	_, err = tx.Exec(`
+		INSERT INTO log_records (
+			time_unix_nano, observed_time_unix_nano, severity_number, severity_text,
+			body, attributes, trace_id, span_id, flags, resource_id, scope_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		timeUnix, observedTime, severityNumber, severityText,
+		string(bodyJSON), string(attributesJSON), traceID, spanID,
+		flags, resourceID, scopeID,
+	)
+
+	return err
+}


### PR DESCRIPTION
## Summary
- Implements basic logs storage functionality for SQLite database
- Adds InsertLogsData and InsertLogRecord functions
- Part 1 of logs storage implementation (basic functionality)

## Changes
- Added `database/logs.go` with logs storage implementation
- Handles all log record fields: timestamps, severity, body, attributes, trace context
- Follows existing patterns from traces and metrics storage
- Uses existing helper functions (GetOrCreateResource, GetOrCreateScope, parseTimeNano)

## Size
- 1 file changed, 139 insertions

## Next PR
- Will add error handling improvements and type safety fixes identified in code review