### PR TITLE
Fix concurrent file write race condition

### DIFF
--- a/handlers/common.go
+++ b/handlers/common.go
@@ -3,7 +3,11 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 )
+
+// writeMutex protects concurrent writes to stdout
+var writeMutex sync.Mutex
 
 func WriteTelemetryData(telemetryType string, body string) error {
 	data := map[string]string{
@@ -16,6 +20,10 @@ func WriteTelemetryData(telemetryType string, body string) error {
 		return fmt.Errorf("failed to marshal telemetry data: %w", err)
 	}
 
+	// Synchronize writes to stdout to prevent race conditions
+	writeMutex.Lock()
 	fmt.Println(string(jsonData))
+	writeMutex.Unlock()
+	
 	return nil
 }


### PR DESCRIPTION
## Summary
This PR fixes the concurrent file write race condition identified in issue #23. When multiple goroutines call `WriteTelemetryData` simultaneously, the output to stdout could become interleaved, resulting in corrupted JSON.

## Changes
- Added `sync.Mutex` to `handlers/common.go` to synchronize writes to stdout
- Wrapped `fmt.Println` call with mutex Lock/Unlock to ensure atomic writes

## Issue Fixed
Fixes #23 (Concurrent File Write Race Condition)

## Testing
Tested with 100 concurrent requests each for metrics, logs, and traces (300 total):

```bash
# Test setup
./sqlite-otel -port 4319 > output.log 2>&1 &

# Sent 300 concurrent requests using custom test program
# Results:
Total JSON output lines: 300
Valid JSON lines: 300
Invalid JSON lines: 0

Breakdown by type:
    100 logs
    100 metrics  
    100 trace

All JSON structures appear complete
```

### Before Fix
Without mutex protection, concurrent writes could produce interleaved output:
```json
{"type":"metrics","bo{"type":"logs","body":"..."}
dy":"..."}
```

### After Fix
With mutex protection, all output remains properly formatted:
```json
{"type":"metrics","body":"..."}
{"type":"logs","body":"..."}
```

## Performance Impact
Minimal - the mutex only protects the actual write operation, not the JSON marshaling or other processing.

## Code Changes
- **Lines changed**: 8 additions
- **Files modified**: 1 (`handlers/common.go`)