### PR TITLE
Fix race conditions in GetOrCreate functions

### DIFF
--- a/DevJournal.md
+++ b/DevJournal.md
@@ -1,5 +1,34 @@
 # Development Journal
 
+## [2025-06-19] - PR #25: Fix Race Conditions in GetOrCreate Functions
+### Actions: 
+- Replaced RETURNING clause with INSERT ON CONFLICT DO NOTHING + SELECT pattern for SQLite 3.24.0+ compatibility
+- Added explicit NULL handling for attributes with default empty map
+- Made resource_id and scope_id NOT NULL in metrics table to prevent NULL duplicates in unique index
+- Removed unused getOrDefault function
+- Implemented code quality improvements from O3-mini and Gemini reviews
+- Added getStringFromMap helper function to reduce code duplication
+- Added documentation for JSON marshaling behavior
+- Wrapped schema creation in transaction for atomicity
+- Added error handling for database close operation
+
+### Decisions:
+- Used INSERT ON CONFLICT DO NOTHING + SELECT pattern instead of RETURNING for broader SQLite compatibility
+- Made all foreign key columns NOT NULL in tables with unique indexes to prevent NULL duplicates
+- Used fmt.Printf for database close errors since log package might not be available during shutdown
+- Kept json.Marshal for attributes serialization with documentation about key sorting behavior
+
+### Challenges:
+- RETURNING clause requires SQLite 3.35.0+ which may not be available in all environments
+- NULL values in unique indexes can lead to duplicate entries in SQLite
+- Balancing between code duplication and over-abstraction when extracting helper functions
+
+### Learnings:
+- SQLite's ON CONFLICT clause (requires 3.24.0+) is more widely supported than RETURNING (requires 3.35.0+)
+- NULL values in unique indexes behave differently in SQLite - multiple rows with NULL values can exist
+- Go's json.Marshal sorts map keys by default, providing canonical output for database comparisons
+- Transaction wrapping for DDL statements ensures atomicity even for CREATE IF NOT EXISTS operations
+
 ## [2025-01-19] - PR #2: v0.2 File Output
 
 ### Actions:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## Overview
 This project involves creating a standalone Go binary that functions as an OpenTelemetry collector service, designed to receive telemetry data and persist it to an embedded SQLite database. The service will be deployable as both an on-demand process and a system service on Linux systems.
 
+## Requirements
+- Go 1.21 or higher
+- SQLite 3.24.0 or higher (for ON CONFLICT clause support)
+
 ## Core Architecture
 The Go binary will implement a lightweight OTEL collector that listens on an ephemeral port for incoming telemetry data (traces, metrics, and logs) in OpenTelemetry Protocol (OTLP) format. Upon receiving data, it will immediately persist the information to a local SQLite database using an embedded database approach. This eliminates external dependencies and simplifies deployment while maintaining data durability.
 

--- a/database/db.go
+++ b/database/db.go
@@ -47,17 +47,17 @@ func createTables() error {
 		// Resources table
 		`CREATE TABLE IF NOT EXISTS resources (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			attributes TEXT,
-			schema_url TEXT
+			attributes TEXT NOT NULL DEFAULT '{}',
+			schema_url TEXT NOT NULL DEFAULT ''
 		)`,
 
 		// Instrumentation scopes table
 		`CREATE TABLE IF NOT EXISTS instrumentation_scopes (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name TEXT,
-			version TEXT,
-			attributes TEXT,
-			schema_url TEXT
+			name TEXT NOT NULL DEFAULT '',
+			version TEXT NOT NULL DEFAULT '',
+			attributes TEXT NOT NULL DEFAULT '{}',
+			schema_url TEXT NOT NULL DEFAULT ''
 		)`,
 
 		// Spans table

--- a/database/db.go
+++ b/database/db.go
@@ -89,8 +89,8 @@ func createTables() error {
 			description TEXT,
 			unit TEXT,
 			type TEXT NOT NULL,
-			resource_id INTEGER,
-			scope_id INTEGER,
+			resource_id INTEGER NOT NULL,
+			scope_id INTEGER NOT NULL,
 			FOREIGN KEY (resource_id) REFERENCES resources (id),
 			FOREIGN KEY (scope_id) REFERENCES instrumentation_scopes (id)
 		)`,

--- a/database/db.go
+++ b/database/db.go
@@ -137,6 +137,7 @@ func createTables() error {
 		// Create unique indexes for deduplication
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_unique ON resources(attributes, schema_url)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_scopes_unique ON instrumentation_scopes(name, version, attributes, schema_url)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_metrics_unique ON metrics(name, type, resource_id, scope_id)`,
 	}
 
 	for _, table := range tables {

--- a/database/shared.go
+++ b/database/shared.go
@@ -157,11 +157,3 @@ func GetOrCreateMetric(tx *sql.Tx, name, description, unit, metricType string, r
 	
 	return id, nil
 }
-
-// getOrDefault returns the value if it exists, otherwise returns the default
-func getOrDefault(data map[string]interface{}, key string, defaultValue interface{}) interface{} {
-	if val, ok := data[key]; ok {
-		return val
-	}
-	return defaultValue
-}


### PR DESCRIPTION
## Summary

This PR fixes race conditions in the GetOrCreate database functions by implementing atomic operations and improving SQLite compatibility.

## Changes

### Core Fixes
1. **Replaced RETURNING clause pattern** with INSERT ON CONFLICT DO NOTHING + SELECT for compatibility with SQLite 3.24.0+ (RETURNING requires 3.35.0+)
2. **Fixed TOCTOU race conditions** by using atomic INSERT ... ON CONFLICT operations
3. **Added NOT NULL constraints** to resource_id and scope_id in metrics table to prevent NULL duplicates in unique indexes
4. **Improved NULL handling** with explicit defaults for attributes (empty map {})

### Code Quality Improvements (from reviews)
1. **Reduced code duplication** by adding getStringFromMap helper function
2. **Added documentation** for JSON marshaling behavior critical for unique indexes
3. **Wrapped schema creation** in transaction for atomicity
4. **Added error handling** for database close operation
5. **Removed unused code** (getOrDefault function)

## Testing
- ✅ Build successful: `go build`
- ✅ Tests pass: `go test ./...` 
- ✅ Manual testing with concurrent requests
- ✅ Verified SQLite compatibility

## Review Status
- ✅ O3-mini review: All issues addressed (only LOW/MEDIUM severity remaining)
- ✅ Gemini review: All issues addressed (only LOW/MEDIUM severity remaining)

Both AI reviewers confirmed the race condition fix is correctly implemented using best practices for SQLite.

Fixes #23 (Race Conditions in GetOrCreate Functions)