### PR TITLE
Fix OTLP/HTTP protocol compliance for error responses

### DIFF
--- a/DevJournal.md
+++ b/DevJournal.md
@@ -1,5 +1,30 @@
 # Development Journal
 
+## [2025-06-19] - PR #27: OTLP/HTTP Protocol Compliance & Improvements
+### Actions:
+- Fixed HTTP status codes to return 500 on database errors (was returning 200)
+- Implemented Content-Type prefix matching for charset support
+- Made file write errors fail the request with proper error response
+- Created ProcessTelemetryRequest common function to eliminate code duplication
+- Reduced each handler from ~65 lines to ~10 lines
+
+### Decisions:
+- Used strings.HasPrefix for Content-Type to support "application/json; charset=utf-8"
+- Made all errors fail fast with appropriate HTTP status codes
+- Created central processing function to ensure consistent behavior across endpoints
+- Kept telemetry type as parameter to maintain clear endpoint separation
+
+### Challenges:
+- Balancing between code reuse and maintaining clear endpoint boundaries
+- Ensuring all error paths return appropriate HTTP status codes
+- Maintaining backward compatibility while improving error handling
+
+### Learnings:
+- OTLP/HTTP spec requires proper HTTP status codes for different error conditions
+- Content-Type headers often include charset parameters that need prefix matching
+- Significant code reduction possible through well-designed common functions
+- Go's function parameters can accept other functions, enabling clean abstraction
+
 ## [2025-06-19] - PR #25: Fix Race Conditions in GetOrCreate Functions
 ### Actions: 
 - Replaced RETURNING clause with INSERT ON CONFLICT DO NOTHING + SELECT pattern for SQLite 3.24.0+ compatibility

--- a/handlers/handler_common.go
+++ b/handlers/handler_common.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// ProcessTelemetryRequest handles common logic for all telemetry endpoints
+func ProcessTelemetryRequest(w http.ResponseWriter, r *http.Request, telemetryType string, insertFunc func(data map[string]interface{}) error) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check Content-Type header (support prefix matching for charset)
+	contentType := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		log.Printf("Unsupported Content-Type for %s: %s", telemetryType, contentType)
+		http.Error(w, "Only application/json Content-Type is supported", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	// Read the request body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("Error reading %s request body: %v", telemetryType, err)
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Write telemetry data to file (maintaining dual storage)
+	if err := WriteTelemetryData(telemetryType, string(body)); err != nil {
+		log.Printf("Error writing %s data to file: %v", telemetryType, err)
+		http.Error(w, fmt.Sprintf("Failed to write %s data", telemetryType), http.StatusInternalServerError)
+		return
+	}
+
+	// Parse JSON body
+	var telemetryData map[string]interface{}
+	if err := json.Unmarshal(body, &telemetryData); err != nil {
+		log.Printf("Error parsing %s JSON: %v", telemetryType, err)
+		http.Error(w, "Invalid JSON format", http.StatusBadRequest)
+		return
+	}
+
+	// Store telemetry data in database
+	if err := insertFunc(telemetryData); err != nil {
+		log.Printf("Error storing %s in database: %v", telemetryType, err)
+		// Return 500 Internal Server Error as per OTLP/HTTP spec
+		http.Error(w, fmt.Sprintf("Failed to process %s data", telemetryType), http.StatusInternalServerError)
+		return
+	}
+
+	// Log request details
+	log.Printf("Received %s request - Content-Type: %s, Content-Length: %d", 
+		telemetryType, r.Header.Get("Content-Type"), len(body))
+
+	// Return success response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{}`))
+}

--- a/handlers/logs.go
+++ b/handlers/logs.go
@@ -1,64 +1,11 @@
 package handlers
 
 import (
-	"encoding/json"
-	"io"
-	"log"
 	"net/http"
 
 	"github.com/RedShiftVelocity/sqlite-otel/database"
 )
 
 func HandleLogs(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	// Check Content-Type header
-	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/json" {
-		log.Printf("Unsupported Content-Type for logs: %s", contentType)
-		http.Error(w, "Only application/json Content-Type is supported", http.StatusUnsupportedMediaType)
-		return
-	}
-
-	// Read the request body
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("Error reading logs request body: %v", err)
-		http.Error(w, "Failed to read request body", http.StatusBadRequest)
-		return
-	}
-	defer r.Body.Close()
-
-	// Write telemetry data to file (maintaining dual storage)
-	if err := WriteTelemetryData("logs", string(body)); err != nil {
-		log.Printf("Error writing logs data to file: %v", err)
-	}
-
-	// Parse JSON body
-	var logsData map[string]interface{}
-	if err := json.Unmarshal(body, &logsData); err != nil {
-		log.Printf("Error parsing logs JSON: %v", err)
-		http.Error(w, "Invalid JSON format", http.StatusBadRequest)
-		return
-	}
-
-	// Store logs in database
-	if err := database.InsertLogsData(logsData); err != nil {
-		log.Printf("Error storing logs in database: %v", err)
-		// Return 500 Internal Server Error as per OTLP/HTTP spec
-		http.Error(w, "Failed to process logs data", http.StatusInternalServerError)
-		return
-	}
-
-	// Log request details
-	log.Printf("Received logs request - Content-Type: %s, Content-Length: %d", 
-		r.Header.Get("Content-Type"), len(body))
-
-	// Return success response
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{}`))
+	ProcessTelemetryRequest(w, r, "logs", database.InsertLogsData)
 }

--- a/handlers/logs.go
+++ b/handlers/logs.go
@@ -48,8 +48,9 @@ func HandleLogs(w http.ResponseWriter, r *http.Request) {
 	// Store logs in database
 	if err := database.InsertLogsData(logsData); err != nil {
 		log.Printf("Error storing logs in database: %v", err)
-		// Note: We don't return an error to the client here to maintain compatibility
-		// The data is still written to file, so we can continue
+		// Return 500 Internal Server Error as per OTLP/HTTP spec
+		http.Error(w, "Failed to process logs data", http.StatusInternalServerError)
+		return
 	}
 
 	// Log request details

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -1,64 +1,11 @@
 package handlers
 
 import (
-	"encoding/json"
-	"io"
-	"log"
 	"net/http"
 
 	"github.com/RedShiftVelocity/sqlite-otel/database"
 )
 
 func HandleMetrics(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	// Check Content-Type header
-	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/json" {
-		log.Printf("Unsupported Content-Type for metrics: %s", contentType)
-		http.Error(w, "Only application/json Content-Type is supported", http.StatusUnsupportedMediaType)
-		return
-	}
-
-	// Read the request body
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("Error reading metrics request body: %v", err)
-		http.Error(w, "Failed to read request body", http.StatusBadRequest)
-		return
-	}
-	defer r.Body.Close()
-
-	// Write telemetry data to file (maintaining dual storage)
-	if err := WriteTelemetryData("metrics", string(body)); err != nil {
-		log.Printf("Error writing metrics data to file: %v", err)
-	}
-
-	// Parse JSON body
-	var metricsData map[string]interface{}
-	if err := json.Unmarshal(body, &metricsData); err != nil {
-		log.Printf("Error parsing metrics JSON: %v", err)
-		http.Error(w, "Invalid JSON format", http.StatusBadRequest)
-		return
-	}
-
-	// Store metrics in database
-	if err := database.InsertMetricsData(metricsData); err != nil {
-		log.Printf("Error storing metrics in database: %v", err)
-		// Return 500 Internal Server Error as per OTLP/HTTP spec
-		http.Error(w, "Failed to process metrics data", http.StatusInternalServerError)
-		return
-	}
-
-	// Log request details
-	log.Printf("Received metrics request - Content-Type: %s, Content-Length: %d", 
-		r.Header.Get("Content-Type"), len(body))
-
-	// Return success response
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{}`))
+	ProcessTelemetryRequest(w, r, "metrics", database.InsertMetricsData)
 }

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -48,8 +48,9 @@ func HandleMetrics(w http.ResponseWriter, r *http.Request) {
 	// Store metrics in database
 	if err := database.InsertMetricsData(metricsData); err != nil {
 		log.Printf("Error storing metrics in database: %v", err)
-		// Note: We don't return an error to the client here to maintain compatibility
-		// The data is still written to file, so we can continue
+		// Return 500 Internal Server Error as per OTLP/HTTP spec
+		http.Error(w, "Failed to process metrics data", http.StatusInternalServerError)
+		return
 	}
 
 	// Log request details

--- a/handlers/traces.go
+++ b/handlers/traces.go
@@ -1,64 +1,11 @@
 package handlers
 
 import (
-	"encoding/json"
-	"io"
-	"log"
 	"net/http"
 
 	"github.com/RedShiftVelocity/sqlite-otel/database"
 )
 
 func HandleTraces(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	// Check Content-Type header
-	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/json" {
-		log.Printf("Unsupported Content-Type for traces: %s", contentType)
-		http.Error(w, "Only application/json Content-Type is supported", http.StatusUnsupportedMediaType)
-		return
-	}
-
-	// Read the request body
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("Error reading traces request body: %v", err)
-		http.Error(w, "Failed to read request body", http.StatusBadRequest)
-		return
-	}
-	defer r.Body.Close()
-
-	// Write telemetry data to file (maintaining dual storage)
-	if err := WriteTelemetryData("trace", string(body)); err != nil {
-		log.Printf("Error writing traces data to file: %v", err)
-	}
-
-	// Parse JSON body
-	var tracesData map[string]interface{}
-	if err := json.Unmarshal(body, &tracesData); err != nil {
-		log.Printf("Error parsing traces JSON: %v", err)
-		http.Error(w, "Invalid JSON format", http.StatusBadRequest)
-		return
-	}
-
-	// Store traces in database
-	if err := database.InsertTraceData(tracesData); err != nil {
-		log.Printf("Error storing traces in database: %v", err)
-		// Return 500 Internal Server Error as per OTLP/HTTP spec
-		http.Error(w, "Failed to process trace data", http.StatusInternalServerError)
-		return
-	}
-
-	// Log request details
-	log.Printf("Received traces request - Content-Type: %s, Content-Length: %d", 
-		r.Header.Get("Content-Type"), len(body))
-
-	// Return success response
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{}`))
+	ProcessTelemetryRequest(w, r, "trace", database.InsertTraceData)
 }

--- a/handlers/traces.go
+++ b/handlers/traces.go
@@ -48,8 +48,9 @@ func HandleTraces(w http.ResponseWriter, r *http.Request) {
 	// Store traces in database
 	if err := database.InsertTraceData(tracesData); err != nil {
 		log.Printf("Error storing traces in database: %v", err)
-		// Note: We don't return an error to the client here to maintain compatibility
-		// The data is still written to file, so we can continue
+		// Return 500 Internal Server Error as per OTLP/HTTP spec
+		http.Error(w, "Failed to process trace data", http.StatusInternalServerError)
+		return
 	}
 
 	// Log request details


### PR DESCRIPTION
## Summary

This PR fixes OTLP/HTTP protocol non-compliance by returning proper HTTP status codes on errors and implements additional improvements suggested in code review.

## Changes

### Core Fix (Original)
- Return HTTP 500 Internal Server Error when database operations fail (previously returned 200 OK)
- Follows OTLP/HTTP specification requirements for error handling

### Additional Improvements (From Review)
1. **Enhanced Content-Type handling** 
   - Now supports prefix matching for `application/json; charset=utf-8`
   - Previously only exact match `application/json` was accepted

2. **File write error handling**
   - File write errors now fail the request with HTTP 500
   - Previously errors were only logged but request succeeded

3. **Eliminated code duplication**
   - Created `ProcessTelemetryRequest` common function
   - Reduced each handler from ~65 lines to ~10 lines
   - Maintains all existing functionality with better maintainability

## Testing
- ✅ Build successful: `go build`
- ✅ Tests pass: `go test ./...`
- ✅ Manually tested all three endpoints
- ✅ Verified error handling works correctly

## Files Changed
- `handlers/traces.go` - Simplified to use common function
- `handlers/metrics.go` - Simplified to use common function  
- `handlers/logs.go` - Simplified to use common function
- `handlers/handler_common.go` - New file with common logic

Fixes #23 (OTLP/HTTP Protocol Non-Compliance)