### PR TITLE
Fix: Rename 'type' column to 'metric_type' to avoid SQL reserved keyword

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -98,7 +98,7 @@ func createTables() error {
 			name TEXT NOT NULL,
 			description TEXT,
 			unit TEXT,
-			type TEXT NOT NULL,
+			metric_type TEXT NOT NULL,
 			resource_id INTEGER NOT NULL,
 			scope_id INTEGER NOT NULL,
 			FOREIGN KEY (resource_id) REFERENCES resources (id),
@@ -147,7 +147,7 @@ func createTables() error {
 		// Create unique indexes for deduplication
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_unique ON resources(attributes, schema_url)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_scopes_unique ON instrumentation_scopes(name, version, attributes, schema_url)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_metrics_unique ON metrics(name, type, resource_id, scope_id)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_metrics_unique ON metrics(name, metric_type, resource_id, scope_id)`,
 	}
 
 	for _, table := range tables {

--- a/database/shared.go
+++ b/database/shared.go
@@ -140,8 +140,8 @@ func GetOrCreateMetric(tx *sql.Tx, name, description, unit, metricType string, r
 	// Use atomic INSERT ... ON CONFLICT DO NOTHING for compatibility with older SQLite
 	// We don't update description/unit on conflict to maintain consistency - first definition wins
 	_, err := tx.Exec(`
-		INSERT INTO metrics (name, description, unit, type, resource_id, scope_id) VALUES (?, ?, ?, ?, ?, ?)
-		ON CONFLICT(name, type, resource_id, scope_id) DO NOTHING`,
+		INSERT INTO metrics (name, description, unit, metric_type, resource_id, scope_id) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(name, metric_type, resource_id, scope_id) DO NOTHING`,
 		name, description, unit, metricType, resourceID, scopeID,
 	)
 	if err != nil {
@@ -152,7 +152,7 @@ func GetOrCreateMetric(tx *sql.Tx, name, description, unit, metricType string, r
 	var id int64
 	err = tx.QueryRow(`
 		SELECT id FROM metrics 
-		WHERE name = ? AND type = ? AND resource_id = ? AND scope_id = ?`,
+		WHERE name = ? AND metric_type = ? AND resource_id = ? AND scope_id = ?`,
 		name, metricType, resourceID, scopeID,
 	).Scan(&id)
 	if err != nil {


### PR DESCRIPTION
## Summary
This PR fixes issue #28 by renaming the `type` column to `metric_type` in the metrics table to avoid using SQL reserved keywords.

## Changes
- Renamed `type` column to `metric_type` in metrics table schema (database/db.go)
- Updated unique index `idx_metrics_unique` to use `metric_type`
- Updated INSERT and SELECT queries in GetOrCreateMetric function (database/shared.go)

## Why This Matters
While SQLite currently allows `type` as a column name, it's problematic because:
- `TYPE` is reserved in other databases (DB2)
- Makes code less portable
- Could break with future SQLite versions
- Violates SQL best practices

## Testing
✅ **Build Test**: `go build` - Successful
✅ **Single Metric Test**: Created database and inserted a counter metric
✅ **Multiple Metric Types Test**: Successfully inserted gauge, sum, and histogram metrics

### Test Results
```bash
# Test 1: Basic metric insertion
./sqlite-otel -port 4320 -db-path ./test-otel.db
curl -X POST http://localhost:4320/v1/metrics -H "Content-Type: application/json" -d '{...}'
# Result: Database created successfully, metric received and stored

# Test 2: Multiple metric types
./sqlite-otel -port 4321 -db-path ./test-multi.db
# Tested gauge, sum, and histogram metrics
# Result: All metric types processed successfully
```

### Verification
- Database files created successfully
- No errors in logs
- Server responds with 200 OK
- Telemetry data written to stdout

## Line Changes
- Total lines changed: 10 (5 additions, 5 deletions)
- Well under the 400 line limit ✅

## Notes
- No changes needed in metrics.go as `metricType` is already used as the variable name
- This is a backward-incompatible schema change, but necessary for long-term compatibility
- Existing databases will need migration if this column existed (but project is pre-v1.0)

Fixes #28