### PR TITLE
Reorganize development roadmap to prioritize Service Mode

### DIFF
--- a/DevJournal.md
+++ b/DevJournal.md
@@ -1,5 +1,24 @@
 # Development Journal
 
+## [2025-06-20] - Roadmap Reorganization
+### Actions:
+- Reordered development roadmap to prioritize Service Mode implementation
+- Moved v0.6 Service Mode to v0.4
+- Moved v0.4 Execution Logging to v0.5
+- Moved v0.5 SQLite Focus to v0.6
+
+### Decisions:
+- Prioritized systemd service integration earlier in the roadmap
+- Service mode capabilities provide more immediate value for deployment scenarios
+- Execution logging and SQLite-only focus can be implemented after service foundation is in place
+
+### Challenges:
+- None - straightforward reorganization of planned features
+
+### Learnings:
+- Service mode integration provides a stable foundation for subsequent features
+- Having service capabilities earlier enables better testing of logging and storage features
+
 ## [2025-06-19] - PR #27: OTLP/HTTP Protocol Compliance & Improvements
 ### Actions:
 - Fixed HTTP status codes to return 500 on database errors (was returning 200)

--- a/README.md
+++ b/README.md
@@ -44,20 +44,20 @@ Database schema will be automatically initialized on first startup, creating tab
 - Write collected data to both file and SQLite simultaneously
 - Database schema initialization
 
-### v0.4 - Execution Logging
+### v0.4 - Service Mode
+- Linux systemd service integration
+- Graceful shutdown handling
+- Service installation and management scripts
+
+### v0.5 - Execution Logging
 - Add dedicated log file for service execution metadata
 - Separate operational logs from telemetry data
 - Log rotation and management capabilities
 
-### v0.5 - SQLite Focus
+### v0.6 - SQLite Focus
 - Remove file output for telemetry data (SQLite only)
 - Maintain execution metadata logging to separate log file
 - Performance optimizations for SQLite operations
-
-### v0.6 - Service Mode
-- Linux systemd service integration
-- Graceful shutdown handling
-- Service installation and management scripts
 
 ### v0.7 - Distribution
 - Cross-platform build system


### PR DESCRIPTION
## Summary
- Reordered development roadmap to implement Service Mode earlier in the development cycle
- This provides a stable foundation for subsequent features like execution logging and SQLite optimization

## Changes Made
- Moved v0.6 Service Mode → v0.4
- Moved v0.4 Execution Logging → v0.5  
- Moved v0.5 SQLite Focus → v0.6
- Updated DevJournal.md with reorganization details and rationale

## Rationale
Service mode integration provides immediate deployment value and creates a stable foundation for testing and implementing the logging and storage optimization features that follow.

## Test plan
- [x] README.md roadmap section updated correctly
- [x] DevJournal.md entry added with reorganization details
- [x] No code changes - documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)