### PR TITLE
feat: add packaging scripts for RPM/DEB and Docker (v0.7 part 3)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Git
+.git
+.gitignore
+
+# Build artifacts
+sqlite-otel-collector
+sqlite-otel-collector-*
+dist/
+build/
+releases/
+
+# Test files
+*.db
+*.db-shm
+*.db-wal
+*.log
+coverage.out
+coverage.html
+
+# Documentation
+*.md
+!README.md
+
+# CI/CD
+.circleci/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/DevJournal.md
+++ b/DevJournal.md
@@ -1,5 +1,43 @@
 # Development Journal
 
+## [2025-06-20] - PR #53: v0.7 Part 3 - Packaging Scripts (RPM/DEB)
+### Actions:
+- Created RPM spec file for building RPM packages
+- Created Debian control files for building DEB packages
+- Added systemd service file with security hardening
+- Created automated build scripts for both package types
+- Added Docker support with multi-stage build
+- Added docker-compose configuration
+
+### Decisions:
+- Use native packaging formats (RPM/DEB) for Linux distributions
+- Create dedicated sqlite-otel user/group for service isolation
+- Apply systemd security hardening (NoNewPrivileges, ProtectSystem, etc.)
+- Follow Filesystem Hierarchy Standard (FHS) for file locations
+- Use multi-stage Docker build to minimize image size
+
+### Challenges:
+- Ensuring compatibility across different RPM/DEB based distributions
+- Balancing security restrictions with functionality requirements
+
+### Learnings:
+- RPM spec files handle pre/post installation scripts differently than DEB
+- systemd security features provide excellent service isolation
+- Multi-stage Docker builds significantly reduce final image size
+
+### Package Features:
+- Automatic user/group creation
+- Systemd service integration with auto-start
+- Security hardening with restricted permissions
+- Proper file locations following FHS
+- Support for RPM (RHEL, CentOS, Fedora) and DEB (Debian, Ubuntu)
+
+### File Locations:
+- Binary: `/usr/bin/sqlite-otel-collector`
+- Database: `/var/lib/sqlite-otel-collector/otel-collector.db`
+- Logs: `/var/log/sqlite-otel-collector.log`
+- Service: `/lib/systemd/system/sqlite-otel-collector.service`
+
 ## [2025-06-20] - Roadmap Reorganization
 ### Actions:
 - Reordered development roadmap to prioritize Service Mode implementation

--- a/DevJournal.md
+++ b/DevJournal.md
@@ -35,8 +35,23 @@
 ### File Locations:
 - Binary: `/usr/bin/sqlite-otel-collector`
 - Database: `/var/lib/sqlite-otel-collector/otel-collector.db`
-- Logs: `/var/log/sqlite-otel-collector.log`
+- Logs: Via journald (systemd journal)
 - Service: `/lib/systemd/system/sqlite-otel-collector.service`
+
+### Code Review Feedback Addressed:
+**Round 1 Issues Fixed:**
+- Added wget to Docker runtime for healthcheck support
+- Added error handling for user/group creation in RPM spec
+- Enhanced systemd security hardening with 10+ additional restrictions
+- Standardized binary installation path to /usr/bin across all methods
+- Added /health endpoint for container healthchecks
+
+**Round 2 Issues Fixed:**
+- Removed /var/log from ReadWritePaths (logs via journald)
+- Made systemd service use explicit --db-path flag
+- Removed unused DB_PATH environment variable
+- Fixed changelog year (2025→2024)
+- Enhanced health check to verify database connectivity
 
 ## [2025-06-20] - Roadmap Reorganization
 ### Actions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# Multi-stage build for SQLite OTEL Collector
+
+# Build stage
+FROM golang:1.21-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache make git
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary
+RUN make build
+
+# Runtime stage
+FROM alpine:3.18
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates tzdata
+
+# Create non-root user
+RUN addgroup -g 1000 -S sqlite-otel && \
+    adduser -u 1000 -S sqlite-otel -G sqlite-otel
+
+# Create data directory
+RUN mkdir -p /var/lib/sqlite-otel-collector && \
+    chown -R sqlite-otel:sqlite-otel /var/lib/sqlite-otel-collector
+
+# Copy binary from builder
+COPY --from=builder /build/sqlite-otel-collector /usr/local/bin/sqlite-otel-collector
+
+# Switch to non-root user
+USER sqlite-otel
+
+# Expose OTLP/HTTP port
+EXPOSE 4318
+
+# Set default database path for container
+ENV DB_PATH=/var/lib/sqlite-otel-collector/otel-collector.db
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:4318/health || exit 1
+
+# Run the collector
+ENTRYPOINT ["/usr/local/bin/sqlite-otel-collector"]
+CMD ["--db-path", "/var/lib/sqlite-otel-collector/otel-collector.db"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,6 @@ USER sqlite-otel
 # Expose OTLP/HTTP port
 EXPOSE 4318
 
-# Set default database path for container
-ENV DB_PATH=/var/lib/sqlite-otel-collector/otel-collector.db
-
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:4318/health || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN make build
 FROM alpine:3.18
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata wget
 
 # Create non-root user
 RUN addgroup -g 1000 -S sqlite-otel && \
@@ -34,7 +34,7 @@ RUN mkdir -p /var/lib/sqlite-otel-collector && \
     chown -R sqlite-otel:sqlite-otel /var/lib/sqlite-otel-collector
 
 # Copy binary from builder
-COPY --from=builder /build/sqlite-otel-collector /usr/local/bin/sqlite-otel-collector
+COPY --from=builder /build/sqlite-otel-collector /usr/bin/sqlite-otel-collector
 
 # Switch to non-root user
 USER sqlite-otel
@@ -50,5 +50,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:4318/health || exit 1
 
 # Run the collector
-ENTRYPOINT ["/usr/local/bin/sqlite-otel-collector"]
+ENTRYPOINT ["/usr/bin/sqlite-otel-collector"]
 CMD ["--db-path", "/var/lib/sqlite-otel-collector/otel-collector.db"]

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,16 @@ build-all:
 	GOOS=darwin GOARCH=amd64 go build -o $(BINARY_NAME)-darwin-amd64 .
 	GOOS=windows GOARCH=amd64 go build -o $(BINARY_NAME)-windows-amd64.exe .
 
-.PHONY: build run clean test build-all
+# Package building
+package-rpm:
+	@echo "Building RPM package..."
+	@./packaging/build-rpm.sh
+
+package-deb:
+	@echo "Building DEB package..."
+	@./packaging/build-deb.sh
+
+package-all: package-rpm package-deb
+	@echo "All packages built successfully"
+
+.PHONY: build run clean test build-all package-rpm package-deb package-all

--- a/database/db.go
+++ b/database/db.go
@@ -9,6 +9,11 @@ import (
 
 var db *sql.DB
 
+// DB returns the database instance for health checks
+func DB() *sql.DB {
+	return db
+}
+
 // InitDB initializes the SQLite database connection and creates tables
 func InitDB(dbPath string) error {
 	var err error

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  sqlite-otel-collector:
+    build: .
+    container_name: sqlite-otel-collector
+    ports:
+      - "4318:4318"
+    volumes:
+      - otel-data:/var/lib/sqlite-otel-collector
+      - otel-logs:/var/log
+    environment:
+      - LOG_LEVEL=info
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4318/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  otel-data:
+    driver: local
+  otel-logs:
+    driver: local

--- a/main.go
+++ b/main.go
@@ -66,6 +66,16 @@ func main() {
 	
 	// Register health endpoint
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		// Check database connectivity with timeout
+		ctx, cancel := context.WithTimeout(r.Context(), 1*time.Second)
+		defer cancel()
+		
+		if err := database.DB().PingContext(ctx); err != nil {
+			log.Printf("Health check failed: database ping error: %v", err)
+			http.Error(w, "Database connection failed", http.StatusServiceUnavailable)
+			return
+		}
+		
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
 	})

--- a/main.go
+++ b/main.go
@@ -64,6 +64,12 @@ func main() {
 	mux.HandleFunc("/v1/metrics", handlers.HandleMetrics)
 	mux.HandleFunc("/v1/logs", handlers.HandleLogs)
 	
+	// Register health endpoint
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	
 	// Create HTTP server
 	server := &http.Server{
 		Handler:      mux,

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,116 @@
+# Packaging for SQLite OTEL Collector
+
+This directory contains packaging scripts and configurations for building RPM and DEB packages.
+
+## Overview
+
+The packaging scripts create installable packages for:
+- **RPM-based systems** (RHEL, CentOS, Fedora, openSUSE)
+- **DEB-based systems** (Debian, Ubuntu)
+
+## Features
+
+- Automatic user/group creation (`sqlite-otel`)
+- Systemd service integration
+- Security hardening with restricted permissions
+- Proper file system hierarchy compliance
+- Pre/post installation scripts
+
+## Building Packages
+
+### Prerequisites
+
+#### For RPM:
+```bash
+# Install RPM build tools
+sudo yum install -y rpm-build rpmdevtools    # RHEL/CentOS
+sudo dnf install -y rpm-build rpmdevtools    # Fedora
+sudo zypper install -y rpm-build             # openSUSE
+```
+
+#### For DEB:
+```bash
+# Install DEB build tools
+sudo apt-get install -y build-essential debhelper dh-systemd devscripts
+```
+
+### Build Commands
+
+```bash
+# Build RPM package
+make package-rpm
+
+# Build DEB package  
+make package-deb
+
+# Build all packages
+make package-all
+```
+
+Built packages will be placed in:
+- `dist/rpm/` - RPM packages
+- `dist/deb/` - DEB packages
+
+## Installation
+
+### RPM-based systems:
+```bash
+sudo rpm -ivh dist/rpm/sqlite-otel-collector-*.rpm
+# or
+sudo yum install dist/rpm/sqlite-otel-collector-*.rpm
+```
+
+### DEB-based systems:
+```bash
+sudo dpkg -i dist/deb/sqlite-otel-collector_*.deb
+# or
+sudo apt install ./dist/deb/sqlite-otel-collector_*.deb
+```
+
+## Service Management
+
+After installation, the service can be managed with systemctl:
+
+```bash
+# Start the service
+sudo systemctl start sqlite-otel-collector
+
+# Enable on boot
+sudo systemctl enable sqlite-otel-collector
+
+# Check status
+sudo systemctl status sqlite-otel-collector
+
+# View logs
+sudo journalctl -u sqlite-otel-collector -f
+```
+
+## File Locations
+
+- **Binary**: `/usr/bin/sqlite-otel-collector`
+- **Service**: `/lib/systemd/system/sqlite-otel-collector.service`
+- **Database**: `/var/lib/sqlite-otel-collector/otel-collector.db`
+- **Logs**: `/var/log/sqlite-otel-collector.log` (when configured)
+- **Config**: `/etc/sqlite-otel-collector/` (future use)
+
+## Security
+
+The service runs as the `sqlite-otel` user with:
+- No new privileges
+- Private tmp directory
+- Read-only system access (except specified paths)
+- Protected home directories
+- Restricted network families (IPv4/IPv6 only)
+- No capabilities
+
+## Uninstallation
+
+### RPM:
+```bash
+sudo rpm -e sqlite-otel-collector
+```
+
+### DEB:
+```bash
+sudo apt-get remove sqlite-otel-collector
+```

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+# Script to build DEB package for sqlite-otel-collector
+
+VERSION=${VERSION:-0.7.0}
+PACKAGE_NAME="sqlite-otel-collector"
+BUILD_DIR="$(pwd)/build/deb"
+
+echo "Building DEB package for $PACKAGE_NAME version $VERSION"
+
+# Clean and create build directory
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+# Create temporary build directory
+TEMP_DIR=$(mktemp -d)
+BUILD_ROOT="$TEMP_DIR/$PACKAGE_NAME-$VERSION"
+mkdir -p "$BUILD_ROOT"
+
+# Copy source files
+echo "Preparing source files..."
+cp -r . "$BUILD_ROOT/"
+cd "$BUILD_ROOT"
+
+# Clean unnecessary files
+rm -rf .git .gitignore build/ dist/ *.db *.log
+
+# Create debian directory
+mkdir -p debian
+cp -r packaging/deb/* debian/
+
+# Create changelog
+cat > debian/changelog << EOF
+$PACKAGE_NAME ($VERSION-1) unstable; urgency=medium
+
+  * Cross-platform build support
+  * Execution logging with rotation
+  * SQLite-only storage
+  * Systemd service integration
+
+ -- Claude Code <noreply@anthropic.com>  $(date -R)
+EOF
+
+# Create compat file
+echo "13" > debian/compat
+
+# Create source format
+mkdir -p debian/source
+echo "3.0 (native)" > debian/source/format
+
+# Build package
+echo "Building DEB package..."
+cd "$TEMP_DIR"
+dpkg-buildpackage -us -uc -b
+
+# Copy built packages to dist
+mkdir -p "$(dirs +0)/dist/deb"
+cp "$TEMP_DIR"/*.deb "$(dirs +0)/dist/deb/" 2>/dev/null || true
+
+# Cleanup
+rm -rf "$TEMP_DIR"
+
+echo "DEB packages built successfully:"
+ls -la dist/deb/

--- a/packaging/build-rpm.sh
+++ b/packaging/build-rpm.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+# Script to build RPM package for sqlite-otel-collector
+
+VERSION=${VERSION:-0.7.0}
+PACKAGE_NAME="sqlite-otel-collector"
+BUILD_DIR="$(pwd)/build/rpm"
+SOURCES_DIR="$BUILD_DIR/SOURCES"
+SPECS_DIR="$BUILD_DIR/SPECS"
+RPMS_DIR="$BUILD_DIR/RPMS"
+
+echo "Building RPM package for $PACKAGE_NAME version $VERSION"
+
+# Clean and create build directories
+rm -rf "$BUILD_DIR"
+mkdir -p "$SOURCES_DIR" "$SPECS_DIR" "$RPMS_DIR"
+
+# Create source tarball
+echo "Creating source tarball..."
+TEMP_DIR=$(mktemp -d)
+mkdir -p "$TEMP_DIR/$PACKAGE_NAME-$VERSION"
+
+# Copy source files
+cp -r . "$TEMP_DIR/$PACKAGE_NAME-$VERSION/"
+cd "$TEMP_DIR/$PACKAGE_NAME-$VERSION"
+
+# Clean unnecessary files
+rm -rf .git .gitignore build/ dist/ *.db *.log
+
+# Create tarball
+cd "$TEMP_DIR"
+tar czf "$SOURCES_DIR/$PACKAGE_NAME-$VERSION.tar.gz" "$PACKAGE_NAME-$VERSION"
+rm -rf "$TEMP_DIR"
+
+# Copy spec file
+cp packaging/rpm/$PACKAGE_NAME.spec "$SPECS_DIR/"
+
+# Update version in spec file
+sed -i "s/Version:.*$/Version:        $VERSION/" "$SPECS_DIR/$PACKAGE_NAME.spec"
+
+# Build RPM
+echo "Building RPM..."
+rpmbuild --define "_topdir $BUILD_DIR" \
+         --define "_version $VERSION" \
+         -ba "$SPECS_DIR/$PACKAGE_NAME.spec"
+
+# Copy built RPMs to dist
+mkdir -p dist/rpm
+find "$RPMS_DIR" -name "*.rpm" -exec cp {} dist/rpm/ \;
+
+echo "RPM packages built successfully:"
+ls -la dist/rpm/

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -1,0 +1,15 @@
+Source: sqlite-otel-collector
+Section: net
+Priority: optional
+Maintainer: Claude Code <noreply@anthropic.com>
+Build-Depends: debhelper-compat (= 13), golang-go (>= 1.21), dh-golang, dh-systemd
+Standards-Version: 4.6.0
+Homepage: https://github.com/RedShiftVelocity/sqlite-otel
+
+Package: sqlite-otel-collector
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: OpenTelemetry collector with SQLite storage
+ A standalone OpenTelemetry collector service that receives telemetry data
+ and persists it to an embedded SQLite database. Supports traces, metrics,
+ and logs via OTLP/HTTP protocol.

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Set proper ownership
+if [ -d /var/lib/sqlite-otel-collector ]; then
+    chown sqlite-otel:sqlite-otel /var/lib/sqlite-otel-collector
+fi
+
+#DEBHELPER#
+
+# Start service on install
+if [ "$1" = "configure" ]; then
+    systemctl --system daemon-reload >/dev/null || true
+    deb-systemd-invoke enable sqlite-otel-collector.service >/dev/null || true
+    deb-systemd-invoke start sqlite-otel-collector.service >/dev/null || true
+fi
+
+exit 0

--- a/packaging/deb/preinst
+++ b/packaging/deb/preinst
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Create user and group
+if ! getent group sqlite-otel >/dev/null; then
+    addgroup --system sqlite-otel
+fi
+
+if ! getent passwd sqlite-otel >/dev/null; then
+    adduser --system --ingroup sqlite-otel --home /var/lib/sqlite-otel-collector \
+        --no-create-home --gecos "SQLite OTEL Collector" sqlite-otel
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -1,0 +1,34 @@
+#!/usr/bin/make -f
+
+export DH_VERBOSE = 1
+export DH_OPTIONS = -v
+
+%:
+	dh $@ --with systemd
+
+override_dh_auto_build:
+	make build
+
+override_dh_auto_install:
+	# Install binary
+	install -D -m 0755 sqlite-otel-collector debian/sqlite-otel-collector/usr/bin/sqlite-otel-collector
+	
+	# Install systemd service
+	install -D -m 0644 packaging/systemd/sqlite-otel-collector.service \
+		debian/sqlite-otel-collector/lib/systemd/system/sqlite-otel-collector.service
+	
+	# Create directories
+	install -d -m 0755 debian/sqlite-otel-collector/var/lib/sqlite-otel-collector
+	install -d -m 0755 debian/sqlite-otel-collector/var/log
+	
+	# Install config if exists
+	if [ -f packaging/config/sqlite-otel-collector.conf ]; then \
+		install -D -m 0644 packaging/config/sqlite-otel-collector.conf \
+			debian/sqlite-otel-collector/etc/sqlite-otel-collector/sqlite-otel-collector.conf; \
+	fi
+
+override_dh_auto_test:
+	go test -v ./...
+
+override_dh_installsystemd:
+	dh_installsystemd --name=sqlite-otel-collector

--- a/packaging/rpm/sqlite-otel-collector.spec
+++ b/packaging/rpm/sqlite-otel-collector.spec
@@ -39,11 +39,17 @@ if [ -f packaging/config/%{name}.conf ]; then
 fi
 
 %pre
-# Create user and group
-getent group sqlite-otel >/dev/null || groupadd -r sqlite-otel
+# Create user and group with error handling
+getent group sqlite-otel >/dev/null || groupadd -r sqlite-otel || {
+    echo "Failed to create group sqlite-otel" >&2
+    exit 1
+}
 getent passwd sqlite-otel >/dev/null || \
     useradd -r -g sqlite-otel -d %{_localstatedir}/lib/%{name} -s /sbin/nologin \
-    -c "SQLite OTEL Collector" sqlite-otel
+    -c "SQLite OTEL Collector" sqlite-otel || {
+    echo "Failed to create user sqlite-otel" >&2
+    exit 1
+}
 exit 0
 
 %post

--- a/packaging/rpm/sqlite-otel-collector.spec
+++ b/packaging/rpm/sqlite-otel-collector.spec
@@ -71,7 +71,7 @@ exit 0
 %endif
 
 %changelog
-* Thu Jun 20 2025 Claude Code <noreply@anthropic.com> - 0.7.0-1
+* Thu Jun 20 2024 Claude Code <noreply@anthropic.com> - 0.7.0-1
 - Initial RPM package
 - Cross-platform build support
 - Execution logging with rotation

--- a/packaging/rpm/sqlite-otel-collector.spec
+++ b/packaging/rpm/sqlite-otel-collector.spec
@@ -1,0 +1,72 @@
+Name:           sqlite-otel-collector
+Version:        0.7.0
+Release:        1%{?dist}
+Summary:        OpenTelemetry collector with SQLite storage
+License:        MIT
+URL:            https://github.com/RedShiftVelocity/sqlite-otel
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  golang >= 1.21
+BuildRequires:  systemd-rpm-macros
+Requires:       systemd
+
+%description
+A standalone OpenTelemetry collector service that receives telemetry data
+and persists it to an embedded SQLite database. Supports traces, metrics,
+and logs via OTLP/HTTP protocol.
+
+%prep
+%autosetup
+
+%build
+# Build the binary
+make build
+
+%install
+# Install binary
+install -D -m 0755 %{name} %{buildroot}%{_bindir}/%{name}
+
+# Install systemd service file
+install -D -m 0644 packaging/systemd/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
+
+# Create directories
+install -d -m 0755 %{buildroot}%{_localstatedir}/lib/%{name}
+install -d -m 0755 %{buildroot}%{_localstatedir}/log
+
+# Install default config (if exists)
+if [ -f packaging/config/%{name}.conf ]; then
+    install -D -m 0644 packaging/config/%{name}.conf %{buildroot}%{_sysconfdir}/%{name}/%{name}.conf
+fi
+
+%pre
+# Create user and group
+getent group sqlite-otel >/dev/null || groupadd -r sqlite-otel
+getent passwd sqlite-otel >/dev/null || \
+    useradd -r -g sqlite-otel -d %{_localstatedir}/lib/%{name} -s /sbin/nologin \
+    -c "SQLite OTEL Collector" sqlite-otel
+exit 0
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+%files
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%dir %attr(0755, sqlite-otel, sqlite-otel) %{_localstatedir}/lib/%{name}
+%if 0%{?_sysconfdir:1}
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
+%endif
+
+%changelog
+* Thu Jun 20 2025 Claude Code <noreply@anthropic.com> - 0.7.0-1
+- Initial RPM package
+- Cross-platform build support
+- Execution logging with rotation
+- SQLite-only storage

--- a/packaging/systemd/sqlite-otel-collector.service
+++ b/packaging/systemd/sqlite-otel-collector.service
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 User=sqlite-otel
 Group=sqlite-otel
-ExecStart=/usr/bin/sqlite-otel-collector
+ExecStart=/usr/bin/sqlite-otel-collector --db-path /var/lib/sqlite-otel-collector/otel-collector.db
 Restart=always
 RestartSec=5
 
@@ -16,7 +16,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/var/lib/sqlite-otel-collector /var/log
+ReadWritePaths=/var/lib/sqlite-otel-collector
 RestrictAddressFamilies=AF_INET AF_INET6
 CapabilityBoundingSet=
 AmbientCapabilities=

--- a/packaging/systemd/sqlite-otel-collector.service
+++ b/packaging/systemd/sqlite-otel-collector.service
@@ -20,6 +20,17 @@ ReadWritePaths=/var/lib/sqlite-otel-collector /var/log
 RestrictAddressFamilies=AF_INET AF_INET6
 CapabilityBoundingSet=
 AmbientCapabilities=
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+MemoryDenyWriteExecute=true
+RestrictNamespaces=true
+PrivateDevices=true
 
 # Resource limits
 LimitNOFILE=65536

--- a/packaging/systemd/sqlite-otel-collector.service
+++ b/packaging/systemd/sqlite-otel-collector.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=SQLite OpenTelemetry Collector
+Documentation=https://github.com/RedShiftVelocity/sqlite-otel
+After=network.target
+
+[Service]
+Type=simple
+User=sqlite-otel
+Group=sqlite-otel
+ExecStart=/usr/bin/sqlite-otel-collector
+Restart=always
+RestartSec=5
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/sqlite-otel-collector /var/log
+RestrictAddressFamilies=AF_INET AF_INET6
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# Resource limits
+LimitNOFILE=65536
+LimitNPROC=4096
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=sqlite-otel-collector
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Implements packaging scripts for creating installable packages as the final part of v0.7 Distribution improvements.

## Changes
- **RPM Packaging**: Complete spec file with pre/post scripts for RPM-based distributions
- **DEB Packaging**: Debian control files and build scripts for DEB-based distributions
- **Systemd Service**: Hardened service file with security restrictions
- **Docker Support**: Multi-stage Dockerfile and docker-compose configuration
- **Build Scripts**: Automated scripts for building packages

## Package Features
- Automatic user/group creation (`sqlite-otel`)
- Systemd service integration with auto-start
- Comprehensive security hardening
- FHS-compliant file locations
- Support for major Linux distributions

## File Locations
- Binary: `/usr/bin/sqlite-otel-collector`
- Database: `/var/lib/sqlite-otel-collector/otel-collector.db`
- Logs: `/var/log/sqlite-otel-collector.log`
- Service: `/lib/systemd/system/sqlite-otel-collector.service`

## Security Hardening
- Runs as dedicated user/group
- NoNewPrivileges enabled
- ProtectSystem=strict
- Private tmp directory
- Restricted network families
- No capabilities

## Test Plan
- [ ] RPM package builds successfully
- [ ] DEB package builds successfully
- [ ] Docker image builds and runs
- [ ] Service starts after package installation
- [ ] Proper file permissions set

## Usage
```bash
# Build packages
make package-rpm
make package-deb
make package-all

# Docker
docker build -t sqlite-otel-collector .
docker-compose up -d
```

🤖 Generated with [Claude Code](https://claude.ai/code)