### PR TITLE
feat: add basic log rotation (PR 1/3)

### DIFF
--- a/logging/rotation.go
+++ b/logging/rotation.go
@@ -1,0 +1,173 @@
+package logging
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RotationConfig defines log rotation parameters
+type RotationConfig struct {
+	MaxSize    int64 // Maximum file size in bytes before rotation (default: 100MB)
+	MaxBackups int   // Maximum number of backup files to keep (default: 7)
+	MaxAge     int   // Maximum age in days to keep backup files (default: 30)
+}
+
+// DefaultRotationConfig returns default rotation configuration
+func DefaultRotationConfig() *RotationConfig {
+	return &RotationConfig{
+		MaxSize:    100 * 1024 * 1024, // 100MB
+		MaxBackups: 7,
+		MaxAge:     30,
+	}
+}
+
+// needsRotationLocked checks if the current log file needs rotation
+// Must be called with l.mu held
+func (l *Logger) needsRotationLocked() bool {
+	if l.file == nil || l.rotationConfig == nil {
+		return false
+	}
+
+	stat, err := l.file.Stat()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to stat log file for rotation check: %v\n", err)
+		return false
+	}
+
+	return stat.Size() >= l.rotationConfig.MaxSize
+}
+
+// rotateLocked performs log file rotation
+// Must be called with l.mu held
+func (l *Logger) rotateLocked() error {
+	if l.file == nil || l.logPath == "" {
+		return nil
+	}
+
+	// Close current file
+	if err := l.file.Close(); err != nil {
+		return fmt.Errorf("failed to close log file: %w", err)
+	}
+
+	// Generate backup filename with timestamp and microseconds for uniqueness
+	timestamp := time.Now().Format("20060102-150405.000000")
+	backupPath := fmt.Sprintf("%s.%s", l.logPath, timestamp)
+
+	// Rename current log file to backup
+	if err := os.Rename(l.logPath, backupPath); err != nil {
+		return fmt.Errorf("failed to rotate log file: %w", err)
+	}
+
+	// Open new log file immediately to unblock logging
+	file, err := os.OpenFile(l.logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open new log file: %w", err)
+	}
+
+	l.file = file
+	// Update multi-writer
+	multiWriter := io.MultiWriter(os.Stdout, file)
+	l.fileLogger.SetOutput(multiWriter)
+
+	// Clean up old backups in the background
+	go l.cleanupOldBackups()
+
+	return nil
+}
+
+// backupFile represents a backup log file with parsed timestamp
+type backupFile struct {
+	path string
+	ts   time.Time
+}
+
+// cleanupOldBackups removes old backup files based on MaxBackups and MaxAge
+// This version is safe to run in a goroutine
+func (l *Logger) cleanupOldBackups() error {
+	if l.logPath == "" || l.rotationConfig == nil {
+		return nil
+	}
+
+	dir := filepath.Dir(l.logPath)
+	base := filepath.Base(l.logPath)
+	expectedPrefix := base + "."
+
+	// Read directory entries
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read log directory: %w", err)
+	}
+
+	var backups []backupFile
+	now := time.Now()
+
+	// Find and parse backup files
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, expectedPrefix) {
+			continue
+		}
+
+		// Parse timestamp from filename
+		timestampPart := strings.TrimPrefix(name, expectedPrefix)
+
+		// Try parsing with microseconds first
+		ts, err := time.Parse("20060102-150405.000000", timestampPart)
+		if err != nil {
+			// Try without microseconds for backward compatibility
+			if ts, err = time.Parse("20060102-150405", timestampPart); err != nil {
+				continue // Not a valid backup file format
+			}
+		}
+		backups = append(backups, backupFile{path: filepath.Join(dir, name), ts: ts})
+	}
+
+	// Sort backups by timestamp, newest first
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].ts.After(backups[j].ts)
+	})
+
+	// Determine which files to delete
+	var toDelete []string
+
+	// Apply MaxBackups policy
+	if l.rotationConfig.MaxBackups > 0 && len(backups) > l.rotationConfig.MaxBackups {
+		for i := l.rotationConfig.MaxBackups; i < len(backups); i++ {
+			toDelete = append(toDelete, backups[i].path)
+		}
+	}
+
+	// Apply MaxAge policy
+	if l.rotationConfig.MaxAge > 0 {
+		cutoff := now.AddDate(0, 0, -l.rotationConfig.MaxAge)
+		for _, backup := range backups {
+			if backup.ts.Before(cutoff) {
+				// Check if already marked for deletion
+				alreadyMarked := false
+				for _, path := range toDelete {
+					if path == backup.path {
+						alreadyMarked = true
+						break
+					}
+				}
+				if !alreadyMarked {
+					toDelete = append(toDelete, backup.path)
+				}
+			}
+		}
+	}
+
+	// Delete identified files
+	for _, path := range toDelete {
+		if err := os.Remove(path); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to remove old backup %s: %v\n", path, err)
+		}
+	}
+
+	return nil
+}

--- a/logging/rotation_test.go
+++ b/logging/rotation_test.go
@@ -1,0 +1,275 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRotationConfig(t *testing.T) {
+	config := DefaultRotationConfig()
+	
+	if config.MaxSize != 100*1024*1024 {
+		t.Errorf("Expected MaxSize to be 104857600, got %d", config.MaxSize)
+	}
+	
+	if config.MaxBackups != 7 {
+		t.Errorf("Expected MaxBackups to be 7, got %d", config.MaxBackups)
+	}
+	
+	if config.MaxAge != 30 {
+		t.Errorf("Expected MaxAge to be 30, got %d", config.MaxAge)
+	}
+}
+
+func TestLogRotation(t *testing.T) {
+	// Create temp directory for test
+	tmpDir, err := os.MkdirTemp("", "log-rotation-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	
+	logPath := filepath.Join(tmpDir, "test.log")
+	
+	// Create logger with small rotation size for testing
+	config := &RotationConfig{
+		MaxSize:    100, // 100 bytes for easy testing
+		MaxBackups: 3,
+		MaxAge:     7,
+	}
+	
+	logger, err := newLoggerWithRotation(logPath, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logger.Close()
+	
+	// Write enough data to trigger rotation
+	for i := 0; i < 20; i++ {
+		logger.Info("Test log message number %d", i)
+	}
+	
+	// Check that rotation occurred
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	if len(entries) < 2 {
+		t.Errorf("Expected at least 2 files after rotation, got %d", len(entries))
+	}
+	
+	// Verify backup file exists
+	foundBackup := false
+	for _, entry := range entries {
+		if entry.Name() != "test.log" && !entry.IsDir() {
+			foundBackup = true
+			break
+		}
+	}
+	
+	if !foundBackup {
+		t.Error("No backup file found after rotation")
+	}
+}
+
+func TestMaxBackupsRetention(t *testing.T) {
+	// Create temp directory for test
+	tmpDir, err := os.MkdirTemp("", "log-rotation-maxbackups-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// Create logger with small rotation size and limited backups
+	config := &RotationConfig{
+		MaxSize:    50, // 50 bytes for easy testing
+		MaxBackups: 3,  // Keep only 3 backups
+		MaxAge:     30, // 30 days (won't affect this test)
+	}
+
+	logger, err := newLoggerWithRotation(logPath, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logger.Close()
+
+	// Write enough data to create multiple rotations
+	// Need to create at least 5 rotations to trigger cleanup of old files
+	for i := 0; i < 6; i++ {
+		// Write enough to exceed MaxSize
+		logger.Info("Test log message number %d to trigger rotation. Adding extra text to ensure we exceed the size limit.", i)
+		// Small delay to ensure different timestamps
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Wait for background cleanup to complete
+	time.Sleep(500 * time.Millisecond)
+
+	// Check that we have exactly MaxBackups + 1 files (current + backups)
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logFiles := 0
+	var fileNames []string
+	for _, entry := range entries {
+		fileNames = append(fileNames, entry.Name())
+		if !entry.IsDir() && (strings.HasPrefix(entry.Name(), "test.log") || entry.Name() == "test.log") {
+			logFiles++
+		}
+	}
+
+	t.Logf("Files in directory: %v", fileNames)
+	
+	// Should have current log + MaxBackups
+	expectedFiles := config.MaxBackups + 1
+	if logFiles != expectedFiles {
+		t.Errorf("Expected %d log files, got %d", expectedFiles, logFiles)
+	}
+}
+
+func TestMaxAgeRetention(t *testing.T) {
+	// Create temp directory for test
+	tmpDir, err := os.MkdirTemp("", "log-rotation-maxage-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// Create some old backup files manually
+	now := time.Now()
+	oldTimestamps := []time.Time{
+		now.AddDate(0, 0, -40), // 40 days old
+		now.AddDate(0, 0, -35), // 35 days old
+		now.AddDate(0, 0, -25), // 25 days old (should be kept)
+		now.AddDate(0, 0, -10), // 10 days old (should be kept)
+	}
+
+	for _, ts := range oldTimestamps {
+		backupName := fmt.Sprintf("test.log.%s", ts.Format("20060102-150405.000000"))
+		backupPath := filepath.Join(tmpDir, backupName)
+		if err := os.WriteFile(backupPath, []byte("old log data"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create logger with MaxAge set to 30 days
+	config := &RotationConfig{
+		MaxSize:    1024 * 1024, // 1MB (won't trigger rotation in this test)
+		MaxBackups: 10,          // High enough to not affect this test
+		MaxAge:     30,          // 30 days
+	}
+
+	logger, err := newLoggerWithRotation(logPath, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger a rotation to invoke cleanup
+	logger.mu.Lock()
+	logger.rotateLocked()
+	logger.mu.Unlock()
+
+	// Wait for background cleanup
+	time.Sleep(100 * time.Millisecond)
+
+	logger.Close()
+
+	// Check remaining files
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Count backup files and check their ages
+	for _, entry := range entries {
+		if entry.Name() == "test.log" {
+			continue // Skip current log
+		}
+
+		if strings.HasPrefix(entry.Name(), "test.log.") {
+			// Parse timestamp from filename
+			tsPart := strings.TrimPrefix(entry.Name(), "test.log.")
+			ts, err := time.Parse("20060102-150405.000000", tsPart)
+			if err != nil {
+				continue
+			}
+
+			age := now.Sub(ts).Hours() / 24 // Age in days
+			if age > 30 {
+				t.Errorf("Found backup file older than %d days: %s (%.0f days old)", 
+					config.MaxAge, entry.Name(), age)
+			}
+		}
+	}
+}
+
+func TestConcurrentLogging(t *testing.T) {
+	// Create temp directory for test
+	tmpDir, err := os.MkdirTemp("", "log-rotation-concurrent-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// Create logger with small rotation size
+	config := &RotationConfig{
+		MaxSize:    1000, // 1KB for frequent rotation
+		MaxBackups: 5,
+		MaxAge:     30,
+	}
+
+	logger, err := newLoggerWithRotation(logPath, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logger.Close()
+
+	// Launch multiple goroutines to write logs concurrently
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	logsPerGoroutine := 50
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < logsPerGoroutine; j++ {
+				logger.Info("Goroutine %d: Message %d - Testing concurrent logging with rotation", id, j)
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Wait for background cleanup
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify no data loss and all files are properly created
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have multiple files due to rotation
+	if len(entries) < 2 {
+		t.Errorf("Expected multiple files due to rotation, got %d", len(entries))
+	}
+
+	// Verify the logger is still functional after concurrent access
+	logger.Info("Final test message after concurrent logging")
+}


### PR DESCRIPTION
## Summary
Part 1 of 3 for implementing log rotation capabilities. This PR adds the core rotation engine without compression.

## Changes
- Added `logging/rotation.go` with size-based rotation logic
- Added `logging/rotation_test.go` with comprehensive tests
- Modified `logging/logger.go` to support rotation infrastructure
- Thread-safe rotation with minimal lock contention

## Technical Details
- Rotation triggered at configurable size (default 100MB)
- Background cleanup of old files based on MaxBackups and MaxAge
- Microsecond timestamps in filenames to prevent collisions
- Filename-based timestamp parsing for reliable sorting

## Test plan
- [x] Run `go build` - builds successfully
- [x] Run `go test ./logging/...` - all tests pass
- [x] Run `go test -race ./logging/...` - no race conditions

## Dependencies
This PR is standalone and can be merged independently.

## What comes next
- PR 2: Add compression support
- PR 3: Integration with main application and CLI flags

🤖 Generated with [Claude Code](https://claude.ai/code)