### PR TITLE
feat: add compression for rotated logs (PR 2/3)

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -17,6 +17,7 @@ var (
 	}
 	loggerMu sync.RWMutex
 	initOnce sync.Once
+	initErr  error // Store initialization error
 )
 
 // Logger handles application logging
@@ -36,17 +37,16 @@ func Init(logFilePath string) error {
 
 // InitWithRotation initializes the logger with rotation configuration
 func InitWithRotation(logFilePath string, config *RotationConfig) error {
-	var err error
 	initOnce.Do(func() {
 		var newL *Logger
-		newL, err = newLoggerWithRotation(logFilePath, config)
-		if err == nil {
+		newL, initErr = newLoggerWithRotation(logFilePath, config)
+		if initErr == nil {
 			loggerMu.Lock()
 			globalLogger = newL
 			loggerMu.Unlock()
 		}
 	})
-	return err
+	return initErr
 }
 
 // newLogger creates a new logger instance

--- a/logging/rotation.go
+++ b/logging/rotation.go
@@ -1,0 +1,68 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// RotationConfig defines log rotation parameters
+type RotationConfig struct {
+	MaxSize int64 // Maximum file size in bytes before rotation (default: 100MB)
+}
+
+// DefaultRotationConfig returns default rotation configuration
+func DefaultRotationConfig() *RotationConfig {
+	return &RotationConfig{
+		MaxSize: 100 * 1024 * 1024, // 100MB
+	}
+}
+
+// needsRotationLocked checks if the current log file needs rotation
+// Must be called with l.mu held
+func (l *Logger) needsRotationLocked() bool {
+	if l.file == nil || l.rotationConfig == nil {
+		return false
+	}
+
+	stat, err := l.file.Stat()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to stat log file for rotation check: %v\n", err)
+		return false
+	}
+
+	return stat.Size() >= l.rotationConfig.MaxSize
+}
+
+// rotateLocked performs log file rotation
+// Must be called with l.mu held
+func (l *Logger) rotateLocked() error {
+	if l.file == nil || l.logPath == "" {
+		return nil
+	}
+
+	// Close current file
+	if err := l.file.Close(); err != nil {
+		return fmt.Errorf("failed to close log file: %w", err)
+	}
+
+	// Generate backup filename with timestamp
+	timestamp := time.Now().Format("20060102-150405.000000")
+	backupPath := fmt.Sprintf("%s.%s", l.logPath, timestamp)
+
+	// Rename current log file to backup
+	if err := os.Rename(l.logPath, backupPath); err != nil {
+		return fmt.Errorf("failed to rotate log file: %w", err)
+	}
+
+	// Open new log file
+	file, err := os.OpenFile(l.logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open new log file: %w", err)
+	}
+
+	l.file = file
+	l.updateFileLogger()
+
+	return nil
+}

--- a/logging/rotation_test.go
+++ b/logging/rotation_test.go
@@ -46,21 +46,26 @@ func TestBasicLogRotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Should have at least 2 files (current log + 1 backup)
-	if len(entries) < 2 {
-		t.Errorf("Expected at least 2 files after rotation, got %d", len(entries))
-	}
-
-	// Verify backup file exists
-	foundBackup := false
+	// Count log files
+	var currentLog, backupFiles int
 	for _, entry := range entries {
-		if entry.Name() != "test.log" && !entry.IsDir() {
-			foundBackup = true
-			break
+		if entry.IsDir() {
+			continue
+		}
+		if entry.Name() == "test.log" {
+			currentLog++
+		} else if len(entry.Name()) > 8 && entry.Name()[:8] == "test.log" {
+			backupFiles++
 		}
 	}
 
-	if !foundBackup {
-		t.Error("No backup file found after rotation")
+	// Should have exactly 1 current log file
+	if currentLog != 1 {
+		t.Errorf("Expected exactly 1 current log file, got %d", currentLog)
+	}
+
+	// Should have at least 1 backup file after rotation
+	if backupFiles < 1 {
+		t.Errorf("Expected at least 1 backup file after rotation, got %d", backupFiles)
 	}
 }

--- a/logging/rotation_test.go
+++ b/logging/rotation_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestRotationConfig(t *testing.T) {
@@ -11,6 +12,10 @@ func TestRotationConfig(t *testing.T) {
 	
 	if config.MaxSize != 100*1024*1024 {
 		t.Errorf("Expected MaxSize to be 104857600, got %d", config.MaxSize)
+	}
+	
+	if !config.Compress {
+		t.Error("Expected Compress to be true by default")
 	}
 }
 
@@ -67,5 +72,81 @@ func TestBasicLogRotation(t *testing.T) {
 	// Should have at least 1 backup file after rotation
 	if backupFiles < 1 {
 		t.Errorf("Expected at least 1 backup file after rotation, got %d", backupFiles)
+	}
+}
+
+func TestCompressFile(t *testing.T) {
+	// Create temp file
+	tmpFile, err := os.CreateTemp("", "compress-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer os.Remove(tmpFile.Name() + ".gz")
+
+	// Write test data
+	testData := "Test data for compression"
+	if _, err := tmpFile.WriteString(testData); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	// Compress file
+	if err := compressFile(tmpFile.Name()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check compressed file exists
+	if _, err := os.Stat(tmpFile.Name() + ".gz"); err != nil {
+		t.Error("Compressed file not found")
+	}
+}
+
+func TestRotationWithCompression(t *testing.T) {
+	// Create temp directory for test
+	tmpDir, err := os.MkdirTemp("", "log-rotation-compress-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// Create logger with compression enabled
+	config := &RotationConfig{
+		MaxSize:  50, // Small size to trigger rotation
+		Compress: true,
+	}
+
+	logger, err := newLoggerWithRotation(logPath, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logger.Close()
+
+	// Write enough data to trigger rotation
+	for i := 0; i < 5; i++ {
+		logger.Info("Test message %d to trigger rotation with compression", i)
+	}
+
+	// Give time for async compression
+	time.Sleep(100 * time.Millisecond)
+
+	// Check for compressed backup
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundCompressed := false
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".gz" {
+			foundCompressed = true
+			break
+		}
+	}
+
+	if !foundCompressed {
+		t.Error("No compressed backup file found")
 	}
 }

--- a/logging/rotation_test.go
+++ b/logging/rotation_test.go
@@ -1,0 +1,66 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRotationConfig(t *testing.T) {
+	config := DefaultRotationConfig()
+	
+	if config.MaxSize != 100*1024*1024 {
+		t.Errorf("Expected MaxSize to be 104857600, got %d", config.MaxSize)
+	}
+}
+
+func TestBasicLogRotation(t *testing.T) {
+	// Create temp directory for test
+	tmpDir, err := os.MkdirTemp("", "log-rotation-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// Create logger with small rotation size for testing
+	config := &RotationConfig{
+		MaxSize: 100, // 100 bytes for easy testing
+	}
+
+	logger, err := newLoggerWithRotation(logPath, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logger.Close()
+
+	// Write enough data to trigger rotation
+	for i := 0; i < 10; i++ {
+		logger.Info("Test log message number %d", i)
+	}
+
+	// Check that rotation occurred
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have at least 2 files (current log + 1 backup)
+	if len(entries) < 2 {
+		t.Errorf("Expected at least 2 files after rotation, got %d", len(entries))
+	}
+
+	// Verify backup file exists
+	foundBackup := false
+	for _, entry := range entries {
+		if entry.Name() != "test.log" && !entry.IsDir() {
+			foundBackup = true
+			break
+		}
+	}
+
+	if !foundBackup {
+		t.Error("No backup file found after rotation")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -30,14 +30,16 @@ func main() {
 	defaultLogPath := getDefaultLogPath()
 	logFile := flag.String("log-file", defaultLogPath, "Path to log file for execution metadata (default: "+defaultLogPath+")")
 	
-	// Log rotation flag
+	// Log rotation flags
 	logMaxSize := flag.Int64("log-max-size", 100, "Maximum size in MB before log rotation (default: 100)")
+	logCompress := flag.Bool("log-compress", true, "Compress rotated log files (default: true)")
 	
 	flag.Parse()
 
 	// Initialize logging with rotation
 	rotationConfig := &logging.RotationConfig{
-		MaxSize: *logMaxSize * 1024 * 1024, // Convert MB to bytes
+		MaxSize:  *logMaxSize * 1024 * 1024, // Convert MB to bytes
+		Compress: *logCompress,
 	}
 	if err := logging.InitWithRotation(*logFile, rotationConfig); err != nil {
 		log.Fatalf("Failed to initialize logging: %v", err)

--- a/main.go
+++ b/main.go
@@ -30,10 +30,16 @@ func main() {
 	defaultLogPath := getDefaultLogPath()
 	logFile := flag.String("log-file", defaultLogPath, "Path to log file for execution metadata (default: "+defaultLogPath+")")
 	
+	// Log rotation flag
+	logMaxSize := flag.Int64("log-max-size", 100, "Maximum size in MB before log rotation (default: 100)")
+	
 	flag.Parse()
 
-	// Initialize logging
-	if err := logging.Init(*logFile); err != nil {
+	// Initialize logging with rotation
+	rotationConfig := &logging.RotationConfig{
+		MaxSize: *logMaxSize * 1024 * 1024, // Convert MB to bytes
+	}
+	if err := logging.InitWithRotation(*logFile, rotationConfig); err != nil {
 		log.Fatalf("Failed to initialize logging: %v", err)
 	}
 	defer logging.Close()


### PR DESCRIPTION
## Summary
Part 2 of 3 for implementing log rotation. This PR adds gzip compression support on top of the basic rotation from PR 1.

## Changes
- Add gzip compression for rotated log files  
- Add `-log-compress` flag (default: true)
- Compression runs asynchronously in background
- Remove uncompressed file after successful compression
- Add tests for compression functionality

## Size
~139 lines - small and focused

## Technical Details
- Compression happens in background goroutine to avoid blocking
- Uses standard gzip compression
- Cleans up uncompressed file after successful compression
- Errors logged to stderr (will be improved in future)

## What's NOT in this PR
- No retention policies (PR 3)
- No WaitGroup for tests (tracked in issue #61)
- No structured error handling for async operations (future enhancement)

## Test plan
- [x] Run `go build` - builds successfully
- [x] Run `go test ./logging/...` - all tests pass
- [x] Manual test with compression enabled
- [x] Gemini code review completed

## Known Limitations
- Test uses time.Sleep (will be fixed per issue #61)
- Errors only logged to stderr (will be improved per issue #61)

🤖 Generated with [Claude Code](https://claude.ai/code)