### PR TITLE
feat: add retention policies (PR 3/3)

### DIFF
--- a/DevJournal.md
+++ b/DevJournal.md
@@ -1,5 +1,28 @@
 # Development Journal
 
+## [2025-06-20] - Log Rotation Implementation (3 Small PRs)
+### Actions:
+- Split original 669-line PR into 3 smaller, focused PRs
+- PR 1: Basic rotation (~195 lines) - size-based rotation only
+- PR 2: Compression (~139 lines) - gzip compression for rotated files
+- PR 3: Retention policies (~200 lines) - MaxBackups and MaxAge cleanup
+
+### Decisions:
+- Each PR builds on the previous one for incremental functionality
+- Async compression/cleanup to avoid blocking log operations
+- Filename-based timestamp parsing for reliable sorting
+- Conservative defaults: 100MB rotation, 7 backups, 30 days retention
+
+### Challenges:
+- Original PR too large for effective review
+- Race condition in InitWithRotation error handling (fixed)
+- Test flakiness with time.Sleep (documented in issue #61)
+
+### Learnings:
+- Smaller PRs are easier to review and merge
+- Incremental feature delivery reduces risk
+- Known limitations can be tracked as issues for future work
+
 ## [2025-06-20] - v0.7 CircleCI Configuration
 ### Actions:
 - Updated existing CircleCI configuration from basic template to comprehensive CI/CD pipeline

--- a/main.go
+++ b/main.go
@@ -32,14 +32,18 @@ func main() {
 	
 	// Log rotation flags
 	logMaxSize := flag.Int64("log-max-size", 100, "Maximum size in MB before log rotation (default: 100)")
+	logMaxBackups := flag.Int("log-max-backups", 7, "Maximum number of old log files to retain (default: 7)")
+	logMaxAge := flag.Int("log-max-age", 30, "Maximum number of days to retain old log files (default: 30)")
 	logCompress := flag.Bool("log-compress", true, "Compress rotated log files (default: true)")
 	
 	flag.Parse()
 
 	// Initialize logging with rotation
 	rotationConfig := &logging.RotationConfig{
-		MaxSize:  *logMaxSize * 1024 * 1024, // Convert MB to bytes
-		Compress: *logCompress,
+		MaxSize:    *logMaxSize * 1024 * 1024, // Convert MB to bytes
+		MaxBackups: *logMaxBackups,
+		MaxAge:     *logMaxAge,
+		Compress:   *logCompress,
 	}
 	if err := logging.InitWithRotation(*logFile, rotationConfig); err != nil {
 		log.Fatalf("Failed to initialize logging: %v", err)


### PR DESCRIPTION
## Summary
Part 3 of 3 for implementing log rotation. This PR adds retention policies on top of the compression from PR 2.

## Changes
- Add MaxBackups to limit number of backup files (default: 7)
- Add MaxAge to remove backups older than N days (default: 30)
- Add `-log-max-backups` and `-log-max-age` command-line flags
- Cleanup runs automatically after each rotation
- Parse timestamps from filenames for reliable sorting
- Add comprehensive tests for both retention policies

## Size
~272 lines - slightly larger due to retention logic and tests

## Technical Details
- Cleanup runs in the same background goroutine as compression
- Uses filename timestamps (not file mtime) for accurate age calculation
- Both policies applied together (files deleted if they exceed either limit)
- Errors logged to stderr (will be improved per issue #61)

## Test plan
- [x] Run `go build` - builds successfully
- [x] Run `go test ./logging/...` - all tests pass
- [x] Manual test with small limits to verify cleanup
- [x] Test both MaxBackups and MaxAge policies

## Complete Feature
With all 3 PRs merged, the log rotation feature includes:
1. Size-based rotation
2. Gzip compression
3. Retention by count and age
4. Command-line configuration
5. Comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)