### PR TITLE
feat: integrate log rotation with CLI configuration

### DIFF
--- a/DevJournal.md
+++ b/DevJournal.md
@@ -1,5 +1,29 @@
 # Development Journal
 
+## [2025-06-20] - Breaking Down Large PR #60 into Smaller PRs
+### Actions:
+- Analyzed PR #60 (668 lines) with Gemini to identify logical breakpoints
+- Split into 3 focused PRs:
+  1. Core rotation engine (PR #62)
+  2. Compression support 
+  3. Integration & configuration
+- Implemented each PR with passing tests
+
+### Decisions:
+- Separated core functionality from features and integration
+- Made compression a separate feature layer
+- Kept CLI flag integration as final step
+
+### Challenges:
+- Original PR too large for comfortable review
+- Ensuring each PR builds and tests independently
+- Managing dependencies between PRs
+
+### Learnings:
+- Breaking down by architectural boundaries works well
+- Core engine → Features → Integration is a natural progression
+- Smaller PRs get reviewed faster and with better quality
+
 ## [2025-06-20] - v0.7 CircleCI Configuration
 ### Actions:
 - Updated existing CircleCI configuration from basic template to comprehensive CI/CD pipeline

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -31,10 +31,15 @@ type Logger struct {
 
 // Init initializes the logger with the given log file path
 func Init(logFilePath string) error {
+	return InitWithRotation(logFilePath, nil)
+}
+
+// InitWithRotation initializes the logger with rotation configuration
+func InitWithRotation(logFilePath string, config *RotationConfig) error {
 	var err error
 	initOnce.Do(func() {
 		var newL *Logger
-		newL, err = newLogger(logFilePath)
+		newL, err = newLoggerWithRotation(logFilePath, config)
 		if err == nil {
 			loggerMu.Lock()
 			globalLogger = newL

--- a/main.go
+++ b/main.go
@@ -30,10 +30,22 @@ func main() {
 	defaultLogPath := getDefaultLogPath()
 	logFile := flag.String("log-file", defaultLogPath, "Path to log file for execution metadata (default: "+defaultLogPath+")")
 	
+	// Log rotation flags
+	logMaxSize := flag.Int("log-max-size", 100, "Maximum size in MB before rotation (default: 100)")
+	logMaxBackups := flag.Int("log-max-backups", 7, "Maximum number of old log files to retain (default: 7)")
+	logMaxAge := flag.Int("log-max-age", 30, "Maximum days to retain old log files (default: 30)")
+	logCompress := flag.Bool("log-compress", true, "Compress rotated log files (default: true)")
+	
 	flag.Parse()
 
-	// Initialize logging
-	if err := logging.Init(*logFile); err != nil {
+	// Initialize logging with rotation
+	rotationConfig := &logging.RotationConfig{
+		MaxSize:    int64(*logMaxSize) * 1024 * 1024, // Convert MB to bytes
+		MaxBackups: *logMaxBackups,
+		MaxAge:     *logMaxAge,
+		Compress:   *logCompress,
+	}
+	if err := logging.InitWithRotation(*logFile, rotationConfig); err != nil {
 		log.Fatalf("Failed to initialize logging: %v", err)
 	}
 	defer logging.Close()


### PR DESCRIPTION
## Summary
Part 3 of 3 for implementing log rotation capabilities. This PR integrates rotation into the main application with CLI configuration.

## Changes
- Added `InitWithRotation()` function to logger package
- Added CLI flags in `main.go`:
  - `-log-max-size`: Maximum size in MB before rotation (default: 100)
  - `-log-max-backups`: Maximum number of old log files (default: 7)
  - `-log-max-age`: Maximum days to retain old files (default: 30)
  - `-log-compress`: Enable/disable compression (default: true)
- Wired rotation config into application startup
- Updated DevJournal with PR breakdown documentation

## Test plan
- [x] Run `go build` - builds successfully
- [x] Run `go test ./...` - all tests pass
- [x] Run `./sqlite-otel -help` - new flags appear correctly

## Dependencies
**Depends on PR #65** - Must be merged after PR #65 (which depends on PR #62)

## Merge order
1. PR #62 - Core rotation engine
2. PR #65 - Compression support
3. PR #66 - This PR (Integration)

🤖 Generated with [Claude Code](https://claude.ai/code)