### PR TITLE
feat: integrate go mod tidy into build pipeline for Go publishing compliance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,19 @@ jobs:
       - checkout
       - setup_go_modules
       - run:
+          name: Verify go.mod is tidy
+          command: |
+            set -e
+            echo "Verifying go.mod and go.sum are tidy..."
+            go mod tidy
+            # Check if go mod tidy changed anything
+            if ! git diff --exit-code go.mod go.sum; then
+              echo "Error: go.mod or go.sum is not tidy"
+              echo "Please run 'go mod tidy' locally and commit the changes"
+              exit 1
+            fi
+            echo "✓ Dependencies are properly tidied"
+      - run:
           name: Build current platform binary
           command: |
             set -e

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,19 @@ tools/
 # Development/test scripts (keep local only)
 test-commands.sh
 scripts/create-release-archives.sh
+
+# MkDocs and build artifacts
+mkdocs-env/
+.cache/
+.tmp/
+site/404.html
+site/api/
+site/cli/
+site/configuration/
+site/deployment/
+site/installation/
+site/quickstart/
+site/search/
+site/sitemap.xml
+site/sitemap.xml.gz
+site/assets_old/

--- a/DevJournal.md
+++ b/DevJournal.md
@@ -1,5 +1,30 @@
 # Development Journal
 
+## [2025-06-22] - PR #84: Go Module Dependency Management Integration
+### Actions:
+- Integrated `go mod tidy` verification into CircleCI build pipeline
+- Updated Makefile to run `go mod tidy` before all build targets (build, build-all, build-linux)
+- Added automated dependency cleanliness checks in CI/CD workflow
+- Fixed existing go.mod issue where dependency was incorrectly marked as `// indirect`
+- Tested changes locally with successful builds and test execution
+
+### Decisions:
+- Follow Go's official publishing guidelines by enforcing tidy modules
+- Fail CI builds if go.mod or go.sum files are not properly maintained
+- Integrate tidy checks early in the build process (after setup_go_modules)
+- Make dependency tidiness a prerequisite for all build operations
+
+### Challenges:
+- Existing go.mod had sqlite3 dependency incorrectly marked as indirect
+- Need to balance build speed vs. dependency verification overhead
+- Ensuring CI/CD fails fast when modules are not tidy
+
+### Learnings:
+- `go mod tidy` catches subtle dependency management issues automatically
+- Integrating dependency checks into CI prevents publishing untidy modules
+- Go publishing best practices require automated enforcement for reliability
+- Module tidiness is essential for proper dependency management in published libraries
+
 ## [2025-06-20] - v0.7 CircleCI Configuration
 ### Actions:
 - Updated existing CircleCI configuration from basic template to comprehensive CI/CD pipeline

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PLATFORMS=linux/amd64 linux/arm64 linux/arm darwin/amd64 darwin/arm64 windows/am
 all: build
 
 # Build for current platform
-build:
+build: tidy
 	@echo "Building ${BINARY_NAME} ${VERSION} for current platform..."
 	go build ${BUILDFLAGS} ${LDFLAGS} -o ${BINARY_NAME} .
 
@@ -57,7 +57,7 @@ test-coverage: test
 	@echo "Coverage report generated: coverage.html"
 
 # Build for all platforms
-build-all:
+build-all: tidy
 	@echo "Building for all platforms..."
 	@mkdir -p dist
 	@for platform in $(PLATFORMS); do \
@@ -71,7 +71,7 @@ build-all:
 	@echo "Build complete. Binaries in dist/"
 
 # Build only Linux binaries (for CI/CD)
-build-linux:
+build-linux: tidy
 	@echo "Building Linux binaries..."
 	@mkdir -p dist
 	@for arch in amd64 arm64 arm; do \

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/RedShiftVelocity/sqlite-otel
 
 go 1.21
 
-require github.com/mattn/go-sqlite3 v1.14.28 // indirect
+require github.com/mattn/go-sqlite3 v1.14.28


### PR DESCRIPTION
## Summary
- Integrate `go mod tidy` verification into CircleCI build pipeline
- Update Makefile to run `go mod tidy` before all build targets 
- Fix existing go.mod dependency marking issue (sqlite3 was incorrectly marked as indirect)
- Add comprehensive .gitignore entries for MkDocs build artifacts
- Ensure full compliance with Go module publishing best practices

## Technical Details
### CircleCI Integration
- Added go mod tidy verification step after dependency setup
- Build fails if go.mod or go.sum are not properly maintained
- Provides clear error messages for developers

### Makefile Updates  
- All build targets (`build`, `build-all`, `build-linux`) now depend on `tidy` target
- Ensures dependencies are cleaned before every build operation
- Maintains consistency across development and CI environments

### Fixed Dependency Issue
- Corrected go.mod where `github.com/mattn/go-sqlite3` was incorrectly marked as `// indirect`
- This dependency is directly imported and should be marked as direct

## Benefits
- ✅ **Compliance**: Follows [Go's official publishing guidelines](https://go.dev/doc/modules/publishing)
- ✅ **Early Detection**: Catches dependency issues before they reach production
- ✅ **Consistency**: Ensures all builds use properly maintained modules
- ✅ **Best Practices**: Automates manual dependency management tasks

## Test plan
- [x] Local build verification (`make build` works and includes tidy step)
- [x] Local test execution (`go test ./...` passes)  
- [x] Binary execution test (`./sqlite-otel --version`)
- [x] Dependency verification (`go mod tidy` produces no changes after running)
- [x] Updated DevJournal.md with technical decisions and learnings

🤖 Generated with [Claude Code](https://claude.ai/code)