### PR TITLE
fix: correct PPA name from sqlite-ote to sqlite-otel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -764,7 +764,7 @@ jobs:
             set -e
             echo "Uploading packages to PPA..."
             
-            PPA_NAME="ppa:manishsinha/sqlite-ote"
+            PPA_NAME="ppa:manishsinha/sqlite-otel"
             
             # Upload all built packages
             for changes_file in ../sqlite-otel-collector_*_source.changes; do
@@ -777,7 +777,7 @@ jobs:
             echo "✅ All packages uploaded to PPA successfully"
             echo ""
             echo "Monitor build status at:"
-            echo "https://launchpad.net/~manishsinha/+archive/ubuntu/sqlite-ote/+packages"
+            echo "https://launchpad.net/~manishsinha/+archive/ubuntu/sqlite-otel/+packages"
       - store_artifacts:
           path: ../
           destination: ppa-packages

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ chmod +x sqlite-otel-darwin-arm64
 #### Ubuntu PPA (Recommended)
 ```bash
 # Add PPA and install
-sudo add-apt-repository ppa:manishsinha/sqlite-ote
+sudo add-apt-repository ppa:manishsinha/sqlite-otel
 sudo apt-get update
 sudo apt-get install sqlite-otel-collector
 


### PR DESCRIPTION
## Summary
- Fixed incorrect PPA name references from `sqlite-ote` to `sqlite-otel`
- Updated README.md installation instructions to use correct PPA
- Updated CircleCI configuration to upload to correct Launchpad PPA

## Changes
- **README.md**: Fixed PPA installation command to use `ppa:manishsinha/sqlite-otel`
- **.circleci/config.yml**: Updated PPA upload target and monitoring URL

## Test plan
- [x] Verified all PPA references are now consistent
- [x] Confirmed other `sqlite-ote` references are correct (package/user names)
- [x] Using `packaging/` branch prefix to trigger comprehensive packaging workflow
- [ ] Test PPA upload with corrected name via CircleCI automation

## Packaging Workflow
This PR uses the `packaging/` branch prefix which triggers:
- ✅ Build and test
- ✅ DEB package build and test
- ✅ RPM package build and test 
- ✅ Docker build and publish
- ✅ Homebrew formula test
- ✅ **PPA build and upload** (with corrected name)

All packaging steps run in parallel after successful tests.

🤖 Generated with [Claude Code](https://claude.ai/code)